### PR TITLE
[ Language ] Kotlin - control code: Loop, Exception, function 

### DIFF
--- a/Language/Java/JavaMultiThreadingConcurrencyAndPerformancOptimization/LockFreePrograming.md
+++ b/Language/Java/JavaMultiThreadingConcurrencyAndPerformancOptimization/LockFreePrograming.md
@@ -1,4 +1,4 @@
-# **Lock Free Programing**
+# **Lock Free Programming**
 
 멀티스레드 프로그래밍의 대부분은 Lock 을 통해 이뤄진다.
 

--- a/Language/Kotlin/ControlCode.md
+++ b/Language/Kotlin/ControlCode.md
@@ -1,0 +1,202 @@
+# 코드를 제어하는 방법
+
+## **제어문(if) 및 Expression**
+
+```java
+// Java
+
+public class Main {
+    public static void main(String[] args) {
+    }
+
+    private void validateScoreIsNotNegative(int score) {
+        if(score < 0) {
+            throw new IllegalArgumentException(String.format("%s는 0보다 작을 수 없습니다."), score);
+        }
+    }
+
+    private String getPassOrFail(int score) {
+        if(score >= 50) {
+            return "P";
+        } else {
+            return "F";
+        }
+    }
+    
+    // 3항 연산자는 하나의 값으로 취급한다. -> Expression 이면서 Statement
+    String grade = score >= 50 ? "P" : "F";
+
+}
+```
+
+```kotlin
+// Kotlin
+
+fun validateScoreIsNotNegative(score: Int) {
+    if(score < 0) {
+        throw IllegalArgumentException("${score}는 0보다 작을 수 없습니다.")
+    }
+}
+
+fun validateScore(score: Int) {
+    if(score !in 0..100) {
+        throw IllegalArgumentException("score 의 범위는 0부터 100입니다.")
+    }
+}
+
+// if-else: Expression 에 해당하여 바로 return 할 수 있다.
+
+fun getPassOrFail(score: Int): String {
+    return if (score >= 50) {
+        "P"
+    } else {
+        "F"
+    }
+}
+```
+
+`if (조건) {}`
+
+- 함수에서는 `Unit`(Java 의 `void`) 가 생략된다.
+- 예외를 던질 때 `new` 를 붙이지 않는다.
+- **자바** 에서 `if-else` 는 `StateMent` 이지만, **코틀린** 에서는 `Expression` 이다.
+
+    ```kotlin
+    val score = 30 + 40 // Expression 이면서 Statement
+
+    // Expression 이기 때문에 바로 return 이 가능하다.
+    fun getPassOrFail(score: Int): String {
+        return if (score >= 50) {
+            "P"
+        } else {
+            "F"
+        }
+    }
+    ```
+
+  - 따라서 코클린에서는 `3항 연산자` 가 존재하지 않는다.
+
+    *Statement 는 프로그램의 문장으로 간주되며 하나의 갑승로 도출되지 않는다. 하지만 Expression 은 하나의 값으로 도출된다.(문장이다.) 따라서 Statement 중에 하나의 값으로 도출되는 문장들이 Expression 이다.*
+
+- 어떠한 값이 특정 범위에 포함되어 있는지, 포함되어 있지 않은지를 확인할 때 간단한게 사용할 수 있다.
+
+    ```kotlin
+    // 자바에서도 동일하다.
+    if(0 <= score && score <= 100) {}
+
+    // 코틀린 문법을 활용
+    if(score in 0..100) {}
+    ```
+
+<br><hr>
+
+## **switch, when**
+
+```java
+// Java
+
+private String getGradeWithSwitch(int score) {
+    switch (score / 10) {
+        case 9:
+            return "A";
+        case 8:
+            return "B";
+        case 7:
+            return "C";
+        default:
+            return "D";
+    }
+}
+
+private boolean startWithA(Object obj) {
+    if (obj isinstanceof String) {
+        return ((String) obj).startsWith("A");
+    } else {
+        return false;
+    }
+}
+
+private void judgeNumber(int number) {
+    if (number == 1 || number == 0 || number == -1) {
+        System.out.println("어디서 많이 본 숫자 입니다.");
+    } else {
+        System.out.println("-1, 0, 1 이 아닙니다.")
+    }
+}
+
+private void judgeNumber2(int number) {
+    if (number == 0) {
+        System.out.println("주어진 숫자는 0 입니다.");
+        return ;
+    } 
+
+    if (number % 2 == 0) {
+        System.out.println("주어진 숫자는 짝수 입니다.");
+    }
+    System.out.println("주어진 숫자는 홀수 입니다.");
+}
+
+```
+
+```kotlin
+// Kotlin
+
+/*
+when (값) {  // 값이 없을 수 도 있음
+    조건부 -> 어떠한 구문 // 조건부에는 어떠한 Expression 이라도 들어갈 수 있으며, 여러개의 조건을 동시에 검사 할 수 있다.
+    조건부 -> 어떠한 구문
+    else -> 어떠한 구문
+}
+*/
+
+// when 또한 expression에 속한다.
+fun getGradeWithSwitch(score: Int): String {
+    return when (score / 10) {
+        9 -> "A"
+        8 -> "B"
+        7 -> "C"
+        else -> "D"
+    }
+}
+
+// 코틀린의 when 은 다양한 조건을 가지고 분기를 칠 수 있다.
+
+fun getGradeWithSwitch(score: Int): String {
+    return when (score) {
+        in 90..99 -> "A"
+        in 80..89 -> "B"
+        in 79..79 -> "C"
+        else -> "D"
+    }
+}
+
+// 조건부에는 어떠한 Expression 이라면 들어올 수 있다.
+fun startsWithA(obj: Any): Boolean {
+    return when (obj) {
+        is String -> obj.startsWith("A")  // 스마트 캐스팅
+        else -> false
+    } 
+}
+
+// 조건부에서 여러 조건을 동시에 검사 할 수 있다.
+fun judgeNumber(number: Int) {
+    when (number) {
+        1, 0, -1 -> println("어디서 많이 본 숫자 입니다.")
+        else -> println("-1, 0, 1 이 아닙니다.")
+    }
+}
+
+fun judgeNumber2(number: Int) {
+    when {
+        number == 0 -> println("주어진 숫자는 0 입니다.")
+        number % 2 -> println("주어진 숫자는 짝수 입니다.")
+        else -> println("주어진 숫자는 홀수 입니다.")
+    }
+}
+
+```
+
+- 자바의 switch 가 사라지고 when 이 생겼다.
+- 자바에서의 case 대신 `->`를 이용한다.
+- 코틀린의 when 은 특정한 값일 경우에 분기를 나눌 수 도 있지만, 이외에도 다양한 조건으로 분기를 나눌 수 있다.
+  - `Enum` class 혹은 `Sealed` Class 와 함께 사용할 경우, 더욱 더 좋다.

--- a/Language/Kotlin/Exception.md
+++ b/Language/Kotlin/Exception.md
@@ -1,0 +1,115 @@
+# **예외를 다루는 방법**
+
+## **try catch finally**
+
+
+```java
+// Java
+
+priavte int parseIntOrThrow(@NotNull String str) {
+    try {
+        return Integer.parseInt(str);
+    } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(String.format("주어진 %s 는 숫자가 아닙니다."), str);
+    }
+}
+
+priavte int parseIntOrThrow2(@NotNull String str) {
+    try {
+        return Integer.parseInt(str);
+    } catch (NumberFormatException e) {
+        return null;
+    }
+}
+```
+
+```kotlin
+// Kotlin
+
+fun parseIntOrThrow(str: String): Int {
+    try {
+        return str.toInt()
+    } catch (e: NumberFormatException) {
+        throw IllegalArgumentException("주어진 ${str} 는 숫자가 아닙니다.")
+    }
+}
+
+fun parseIntOrThrow2(str: String): Int? {
+    return try {
+        str.toInt()
+    } catch (e: NumberFormatException) {
+        null
+    }
+}
+```
+
+코틀린에서 `try-catch-finally` 의 문법은 자바와 완전히 동일하다.
+
+- 기본 타입간의 형변환은 `toType()` 을 사용한다.
+- 타입이 뒤에 위치하며, `new` 를 사용하지 않는다.
+- `포매팅` 이 간결하다.
+- `try-catch-finally` 는 하나의 `Expression` 으로 간주된다.
+
+<br><hr>
+
+## **Checked Exception 과 Uncheckecd Exception**
+
+```java
+// Java
+
+public class JavaFilePrinter {
+    public void readFile() throws IOException {
+        File currentFile = new File(".");
+        File file = new File(currentFile.getAbsolutePath() + "/a.txt)");
+        BufferedReader reader = new BufferedReader(new FileReader(file));
+        System.out.println(reader.readLine());
+        reader.close();
+    }
+    
+}
+```
+
+```kotlin
+// Kotlin
+
+class FilePrinter {
+    val currentFile = File(".")
+    val file = File(currentFile.absolutePath + "a.txt")
+    val reader = BufferedReader(FileReader(file))
+    println(reader.readLine())
+    reader.close()
+}
+```
+
+코틀린에서는 `Checked Exception` 과 `Unchecked Exception` 을 구분하지 않는다.
+
+- 모두 `Unchecked Exception` 에 해당한다.(throws 를 볼일이 거의 없다.)
+
+<br><hr>
+
+## **try with resources**
+
+```java
+// Java
+
+public void readFile(String path) throw IOException {
+    // try 와 괄호가 생겨 괄호 안에 외부 자원을 만들어주고 try가 끝나면 자동으로 외부 자원을 닫아준다.
+    try (BufferedReader reader = new BufferedReader(new FileReader(path))) { 
+        System.out.println(reader.readLine());
+    }
+}
+```
+
+```kotlin
+// Kotlin
+
+fun readFile(path: String) {
+    BufferedReader(FileReader(path)).use { reader ->
+        println(reader.readLine())
+    }
+}
+```
+
+코틀린에는 `try with resources` 구문이 **없**고, `uss` 를 사용한다.
+
+- `use` 는 `inline 확장함수` 를 이야기한다.

--- a/Language/Kotlin/Loop.md
+++ b/Language/Kotlin/Loop.md
@@ -1,0 +1,108 @@
+# **반복문을 다루는 방법**
+
+코틀린의 반복문은 자바와 거의 유사하다.
+
+## **for**
+
+```java
+// Java
+
+// for-each(향상된 for 문)
+List<Long> numbers = Arrays.asList(1L, 2L, 3L);
+for (long number: numbers) {
+    System.out.println(number);
+}
+
+// 전통적인 for 문
+for(int i = 1; i  <= 3; i++) {
+    System.out.println(i)
+}
+
+for(int i = 3; i  >= 1; i--) {
+    System.out.println(i)
+}
+
+```
+
+```kotlin
+// Kotlin
+
+// for-each
+fun forEach() {
+    val numbers = listOf(1L, 2L, 3L)
+    for (number in numbers) {
+        println(number)
+    }
+}
+
+
+// 전통적인 for 문
+fun traditionalFor() {
+    for(i in 1..3) {
+        println(i)
+    }
+}
+
+fun traditionalFor2() {
+    for(i in 3 downTo 1) {
+        println(i)
+    }
+}
+
+fun traditionalFor3() {
+    for(i in 1..5 step 2) {
+        println(i)
+    }
+}
+
+```
+
+`..`: 범위를 만들어 내는 연산자
+
+- 컬렉션을 만드는 방법에 차이가 존재한다.
+- 콜론(`:`) 대신 `in` 을 사용한다.
+  - 자바와 동일하게 `Iterable` 이 구현된 타입이라면 모두 들어갈 수 있다.
+- `..` 을 통해 범위를 나타낸다.
+- 값이 감소하는 경우, `downTo` 를 통해 표햔한다.
+- 값이 `n` 씩 올라가는 경우 `step n` 을 사용한다.
+
+<br>
+
+코클린에서 `전통적인 for` 문은 등차수열을 이용한다.
+
+- `IntProgression`(등차수열) 을 `IntRange` 가 구현한 형태이다.
+- `1..3`: 1에서 시작하고 3으로 끝나는 등차수열을 만들어라
+  - 시작 값: 1
+  - 끝 값: 3
+  - 공차: 1
+- `downTo` 와 `step` 은 **(중위)합수** 이다.
+
+    *중위 함수는 `변수.함수이름(argument)` 대신 `변수 함수이름 argument` 으로 호출 할 수 있게 하는 함수를 말한다.*
+
+<br> <hr>
+
+## **while**
+
+```java
+// Java
+
+int i = 1;
+while (i <= 3) {
+    System.out.println(i);
+    i++;
+}
+```
+
+```kotlin
+// Kotlin
+
+var i = 1;
+while (i <= 3) {
+    println(i)
+    i++
+}
+```
+
+`while` 문은 자바와 동일하다.
+
+- `do-while` 또한 동일하다.

--- a/Language/Kotlin/VariablesTypesOperators.md
+++ b/Language/Kotlin/VariablesTypesOperators.md
@@ -332,7 +332,7 @@ fun printAgeIfPerson(obj: Any) {
 }
 
 fun printAgeIfPerson(obj: Any) {
-     if(obj !is Person)  // obj 가 Person 이 라면
+     if(obj is Person) { // obj 가 Person 이 라면
         val person = obj as Person // obs를 Person으로써 간주하여 person 변수에 할당한다. as Person은 생략 가능하다.
         println(person.age)
     }

--- a/Language/Kotlin/function.md
+++ b/Language/Kotlin/function.md
@@ -1,0 +1,134 @@
+# **함수를 다루는 방법**
+
+## **함수 선언 문법**
+
+```java
+// Java
+
+public int max(int a, int b) {
+    if (a > b) {
+        return a;
+    } 
+    return b;
+}
+```
+
+```kotlin
+// Kotlin
+
+fun max(a: Int, b: Int): Int =
+     if (a > b) {
+        a
+    } else {
+        b
+    }
+
+// 반환타입 생략 가능(어떤 경우 건, Int 타입을 반환하기 때문에 추론됨) 단 생략하기 위해서는 함수를 작성할 때 중괄호 대신 = 을 써야한다.
+// body가 하나의 값으로 간주되는 경우 block 을 없앨 수 있으며, block 이 없다면 반환 타입을 업앨 수도 있다.
+// 조건분의 중괄호 생략가능
+fun improvedMax(a: Int, b: Int) =  if (a > b) a else b 
+
+```
+
+- `public` 은 접근 지시어로, `public` 은 생략 가능하다.
+- `fun` 은 함수를 의미하는 키워드이다.
+- 함수는 클래스 안에 있을 수도, 파일 최상단에 존재할 수도 있다.
+  - 한 파일 안에 여러 함수들이 존재할 수 있다.
+- `body` 가 하나의 값으로 간주되는 경우 `block` 을 없앨 수 있으며, `block` 이 없다면 반환 타입을 없앨 수도 있다.
+- 매개변수는 `매개변수: 매개변수 타입` 으로 선언한다.
+- 반환타입은 `Unit`(자바의 `void`) 일경우 생략 가능하다.
+  - `block {}` 을 사용하는 경우, 반환 타입이 `Unit` 이 아니라면, 반환 타입을 명시적으로 작성해주어야한다.
+  - `=` 을 사용할 경우 **타입 추론이 가능** 하다.
+
+<br><hr>
+
+## **Default Parameter**
+
+```java
+// Java
+
+
+public void repeat(String str, int num, boolean useNewLine) {
+    for (int i = 1; i <= num; i++) {
+        if (useNewLine) {
+            System.out.println(str);
+        } else {
+            System.out.print(str);        }
+    }
+}
+
+// useNewLine 이 자주 true 로 사용될 경우, 오버로딩을 활용한다.
+public void repeat(String str, int num) {
+    repeat(str, num, true);
+}
+```
+
+```kotlin
+// Kotlin
+
+fun main() {
+    repeat("Hello World", useNewLine=false) // named argument
+}
+
+// 기본 값(default)을 지정할 수 있다.
+fun repeat(
+    str: String,
+    num: Int = 3, 
+    useNewLine: Boolean = true
+) {
+    for (i in 1..num) {
+        if (useNewLine) {
+            println(str)
+        } else {
+            print(str)
+        }
+    }
+}
+```
+
+- 코틀린에서는 `기본값(default)` 값을 지정할 수 있다.
+  - 사용 시, 파라미터를 넣어주지 않으면 기본 값을 사용한다.
+  - 함수를 **호출하는 쪽** 에서 **매개변수 이름을 직접 지정하여 파라미터를 사용할 수 있다.**(`named argument`)
+    - builder 를 직접 만들지 않고 builder 의 장점을 갖을 수 있다.
+    - 단, 코틀린에서 자바 함수를 가져다 사용할 경우 `named argument` 를 사용할 수 없다.
+- 코틀린에도 자바와 동일하게 `오버로드` 기능이 존재한다.
+
+<br><hr>
+
+## **같은 타입의 여러 파라미터 받기(가변인자)**
+
+```java
+// Java
+
+public static void printAll(String... strings) { // 타입... 을 사용하면 가변인자를 사용한더는 의미이다.
+    for (String str : strings) {
+        System.out.println(str);
+    }
+}
+
+// 해당 코드를 사용하는 경우
+String[] array = new String[]{"A", "B", "C"};
+printAll(array);
+printAll("A", "B", "C");
+```
+
+```kotlin
+// Kotlin
+
+fun main() {
+    printAll("A", "B", "C")
+
+    val array = arrayOf("A", "B", "C")
+    printAll(*array) // 바로 배열을 넣어줄 경우 spread 연산자 * 를 사용한다.
+}
+
+fun printALl(vararg strings: String) {
+    for (str in strings) {
+        println(str)
+    }
+}
+```
+
+`가변인자` 함수를 만들경우 `vararg` 키워드를 사용한다.
+
+- `가변인자` 함수를 배열과 호출할 때는 `*(spread 연산자)` 를 사용해야 한다.


### PR DESCRIPTION
## [ Language ] Kotlin - control code: If, Loop, Exception, function 


## 작업내용

> ### 제어문 과 Expression

코틀린에서의 조건문은 자바와 거의 유사하나, 다음 차이점이 존재한다.

- **자바** 에서 `if-else` 는 `StateMent` 이지만, **코틀린** 에서는 `Expression` 이다.
- 코클린에서는 `3항 연산자` 가 존재하지 않는다.
- 자바의 `switch` 가 사라지고 `when` 이 존재한다.
  - 자바에서의 case 대신 `->`를 이용한다.  
  - 코틀린의 when 은 특정한 값일 경우에 분기를 나눌 수 도 있지만, 이외에도 다양한 조건으로 분기를 나눌 수 있다.

<br>

> ### 반복문

코틀린의 반복문은 `..` 을 통해 구현한다.

- `..` 을 통해 범위를 나타낸다.
- 콜론(`:`) 대신 `in` 을 사용한다.
  - 자바와 동일하게 `Iterable` 이 구현된 타입이라면 모두 들어갈 수 있다.
- 값이 감소하는 경우, `downTo` 를 통해 표햔한다.
- 값이 `n` 씩 올라가는 경우 `step n` 을 사용한다.
-  `전통적인 for` 문은 등차수열을 이용한다.
  - `IntProgression`(등차수열) 을 `IntRange` 가 구현한 형태이다.
  - `downTo` 와 `step` 은 **(중위)합수** 이다.
- `while` 문 과 `do-while`은 자바와 동일하다.

<br>

> ### 함수

함수는 클래스 안에 있을 수도, 파일 최상단에 존재할 수도 있다.

- `public` 은 접근 지시어로, `public` 은 생략 가능하다.
- `fun` 은 함수를 의미하는 키워드이다.
- 한 파일 안에 여러 함수들이 존재할 수 있다.
- `body` 가 하나의 값으로 간주되는 경우 `block` 을 없앨 수 있으며, `block` 이 없다면 반환 타입을 없앨 수도 있다.
- 매개변수는 `매개변수: 매개변수 타입` 으로 선언한다.
- 반환타입은 `Unit`(자바의 `void`) 일경우 생략 가능하다.
  - `block {}` 을 사용하는 경우, 반환 타입이 `Unit` 이 아니라면, 반환 타입을 명시적으로 작성해주어야한다.
  - `=` 을 사용할 경우 **타입 추론이 가능** 하다.
- 코틀린에서는 `기본값(default)` 값을 지정할 수 있다.
- 코틀린에도 자바와 동일하게 `오버로드` 기능이 존재한다.
- `가변인자` 함수를 만들경우 `vararg` 키워드를 사용한다.
  - `가변인자` 함수를 배열과 호출할 때는 `*(spread 연산자)` 를 사용해야 한다.

<br>

> ### 예외

코틀린에서 `try-catch-finally` 의 문법은 자바와 완전히 동일하다.

- `try-catch-finally` 는 하나의 `Expression` 으로 간주된다.
- `Checked Exception` 과 `Unchecked Exception` 을 구분하지 않는다.
- `try with resources` 구문이 **없**고, `uss` 를 사용한다.

<hr>


## 컨텍스트

비슷하면서도 자바와는 많이 다른 부분을 공부할 수 있었다. 해당 부분을 공부하면서 내가 잘 모르고 있던 부분 또한 공부할 수 있었다.

> **Statement 와 Expression**

나는 솔직하게 `Statement` 와 `Expression` 을 구분하지 못했다.

- `Statement`: 특정 동작이나 작업을 수행하는 코드 단위(명령)를 말한다.
- `Expression`: 단일 값으로 평가되는 변수, 값, 연산자 및 함수 호출의 조합을 의미하며, 값을 계산하거나 계산하는 데 사용된다.

<br>

정확하게는, `Statement` 와 `Expression` 에 대해 알지 못한 채 사용하고 있던 것이다. 그리고 나는 `Expression` 을 주로 사용했다.

- 코드를 간결하게 할 수 있었다.
- (개인적으로) 가독성이 증진되었다.

그리고 이번 기회를 통해 `Statement` 와 `Expression` 의 차이를 알 수 있었다.

- `Statement` 는 작업을 수행하거나 코드 흐름을 제어하기 위해 실행되는 반면 `Expression` 은 값을 생성하기 위해 사용 된다.

<br>

추가적으로, 이번 코드 제어 관련 문법들을 정리하면서, `파이썬` 을 처음 배우던  과거의 내 모습이 떠올랐다.

> **파이썬 에서 자바로**

나는 `파이썬`을 통해 코딩에 입문했고, `파이썬` 을 공부할 수 있었던 이유는 **파이썬이  사용자 친화적인 언어** 이었기 때문이라 생각한다.

- 당시 `파이썬` 을 처음 알게 되었을 때, 나는 엑셀을 공부하고 있었다. 그리고 엑셀이 잘 와닫지 않고, 비효율적이라고 생각하던 내게, 파이썬은 엄청나게 직관적이며 효율적이고 혁명적인 도구였다.
- 하지만 `파이썬` 으로 개발을 하고 업무를 진행하면서, 불편한 점이 점점 생겨났다.

<br>

다양한 코딩 관련 주제들(클린 코드, 클린 아키텍처 등)을 공부하면서, 파이썬이 점점 불편해져갔다.  그  가장 큰 원인은 `타입 힌트` 이다.

- `파이썬`에서 `타입 힌트 ` 할 수 있다. 하지만 의무가 아니다. 강제할 수 없다.

<br>

나는 `타입힌트` 는 클린 코드를 위해, 그리고 개발자를 위해 꼭 필요하다고 생각한다.

- `타입힌트` 는 함수 명, 변수명과 함께 코드를 예측할 수 있게 해준다.
- 다른 함수이면서 같은 이름의 변수를 갖는 경우 정말 `타입힌트` 가 나는 절실히 필요하다 생각했다.
- 하지만 같이 개발하는 사람이 `타입힌트` 를 사용하지 않는다면 강요할 수 없다..
- 그래서 타입을 반드시 명시해야하는 `자바` 에 관심이 생기기 시작했다.

<br>

하지만, `자바` 는 다소 많이 불편했다. 새롭게 배우는 언어이기에 당연한거겠지만,  **"이건 왜이렇지?"** 하는 부분이 많았다. 그런데 `코틀린`을 알게된 후, `코틀린` 은 내게 한줄기 빛이 되었다.

> **자바와 코틀린**

 `코틀린` 은 내게 `파이썬` 같은 `자바` 같다.

- `자바` 와 100% 호환이 되며 거의 유사하다. 타입은 명시해야하고, (개인적으로) 직관적이다.
- `자바` 와 `파이썬` 에서 느낀 불편한 부분이 없다. 심지어 `파이썬` 에선 한계라 생각한 부분(멀티스레딩)도 극복할 수 있다.

<br>

이야기가 삼천포로 빠졌지만, `코틀린` 을 공부하면서 처음 코딩을 공부하던 때가 생각이 많이 난다. 그 때 느꼈던 **설렘과 즐거움** 이 요즘 많이 들어서 행복하다. `파이썬` 도, `자바` 와 `코틀린` 도 함께 공부하고 같이 개발에 사용하고 싶다. 특히 코루틴을 사용해서 개발을 너무너무 해보고 싶다.

***내가 목표 중 하나인, 대부분의 통신을 `비동기-논블로킹` 으로 이뤄진 시스템을 개발하는데 한 걸음 더 나아갈 수 있지 않을까? 하는 행복한 상상을 해본다!***